### PR TITLE
Fix mongoose deprecation warnings

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -3,7 +3,14 @@ let { MONGODB_CONNECTION_STRING } = require("./config");
 
 const url = MONGODB_CONNECTION_STRING;
 
-mongoose.connect(url);
+// Avoid deprecation warnings: https://mongoosejs.com/docs/deprecations.html
+const options = {
+  useNewUrlParser: true,
+  useCreateIndex: true,
+  useUnifiedTopology: true
+}
+
+mongoose.connect(url, options);
 
 mongoose.connection.on("connected", function() {
   console.log("Mongoose connected to " + url);


### PR DESCRIPTION
- `npm run dev` should no longer show any deprecation warnings.